### PR TITLE
Fixed issue with listeners not unsubscribing

### DIFF
--- a/src/components/grid/index.js
+++ b/src/components/grid/index.js
@@ -74,12 +74,12 @@ class Grid extends Component {
     referenceSizeProvider: this.state.referenceSizeProvider,
   });
 
-  componentWillMount() {
-    Dimensions.addEventListener('change', this.windowResizeHandler.bind(this));
+  componentDidMount() {
+    Dimensions.addEventListener('change', this.windowResizeHandler);
   }
 
   componentWillUnmount() {
-    Dimensions.removeEventListener('change', this.windowResizeHandler.bind(this));
+    Dimensions.removeEventListener('change', this.windowResizeHandler);
   }
 
   onLayout = ({ nativeEvent: { layout: { width, height } } }) => {


### PR DESCRIPTION
Solves #26.
Additionally, it changes when it subscribes, this future-proofs for following [RFC](https://github.com/reactjs/rfcs/blob/master/text/0006-static-lifecycle-methods.md) expected to deprecate most `componentWill*` methods starting with React 16.4.