### PR TITLE
fix(Section): use alignSelf to stretch

### DIFF
--- a/src/components/section/index.js
+++ b/src/components/section/index.js
@@ -19,6 +19,7 @@ const styles = StyleSheet.create({
   },
   stretch: {
     flex: 1,
+    alignSelf: 'stretch',
   },
 });
 


### PR DESCRIPTION
On web, sections are not stretched despite using `stretchable` prop on `Grid` and `stretch` on `Section`. This PR fixes the issue using `alignSelf`.