### PR TITLE
fix: make props in TS types optional

### DIFF
--- a/src/components/block/index.js
+++ b/src/components/block/index.js
@@ -37,7 +37,7 @@ const style = StyleSheet.create({
  * - otherwise it will choose smallest class defined that is applicable based
  *   on sizing of closest outer `Grid` element
  *
- * @type {React.StatelessComponent<{size: string | number, hidden: boolean, visible: boolean, style: any, children: any}>}
+ * @type {React.StatelessComponent<{size?: string | number, hidden?: boolean, visible?: boolean, style?: any, children: any}>}
  */
 /* eslint-enable */
 const Block = ({

--- a/src/components/grid/index.js
+++ b/src/components/grid/index.js
@@ -41,7 +41,7 @@ const styles = StyleSheet.create({
  * Using `relativeTo` set to 'self' can have performance impact since it must
  * determine whether children components are impacted by resize.
  *
- * @augments {Component<{breakpoints: Object, horizontal: boolean, scrollable: boolean, relativeTo: 'window' | 'self' | 'parent', stretchable: boolean, style: any, children: any}>}
+ * @augments {Component<{breakpoints?: Object, horizontal?: boolean, scrollable?: boolean, relativeTo?: 'window' | 'self' | 'parent', stretchable?: boolean, style?: any, children: any}>}
  */
 /* eslint-enable */
 class Grid extends Component {

--- a/src/components/section/index.js
+++ b/src/components/section/index.js
@@ -27,7 +27,7 @@ const styles = StyleSheet.create({
 /**
  * Component used to contain group of Blocks.
  *
- * @type {React.StatelessComponent<{stretch: boolean, style: any, children: any}>}
+ * @type {React.StatelessComponent<{stretch?: boolean, style?: any, children: any}>}
  */
 const Section = ({ children, style, stretch }, { gridContentDirection, gridStretch }) => {
   if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Currently, all types in TypeScript are required. This fix makes them optional.